### PR TITLE
Bugfix session auth verify

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -6,7 +6,7 @@ const { setUser, cors } = require('./lib/middleware')
 const { saveUser, getUser, getUserByEmail, getAllUsers } = require('./lib/userlist')
 const router = express.Router()
 
-const privateSecret = 'reallygreatc0der'
+const privateSecret = require('./lib/fakeEnv').JWT_PRIVATE_SECRET
 
 // For CORS. Must be placed at the top so this handles
 // cors request first before propagating to other middlewares

--- a/src/auth.test.js
+++ b/src/auth.test.js
@@ -1,0 +1,50 @@
+/* globals describe it jest expect */
+const { app } = require('../server')
+const request = require('supertest')
+const jwt = require('jsonwebtoken')
+
+// Prevent actual db writes/reads
+jest.mock('./lib/db', () => ({
+  getData: jest.fn().mockResolvedValue({}),
+  setData: jest.fn().mockReturnValue(null)
+}))
+
+describe('auth (js5/p6)', () => {
+  const mockUser = { username: 'tom', email: 'tom@tom' }
+
+  const validResponse = expect.objectContaining({
+    ...mockUser,
+    jwt: expect.any(String)
+  })
+
+  // set real jwt when creating user
+  let realJwt
+  it('creating a user return a jwt', async () => {
+    const response = await request(app)
+      .post('/auth/api/users')
+      .send({
+        ...mockUser,
+        password: 'anything'
+      })
+
+    expect(response.body).toEqual(validResponse)
+    realJwt = response.body.jwt
+  })
+  it('can get session with jwt', async () => {
+    const response = await request(app)
+      .get('/auth/api/session')
+      .set('Authorization', `Bearer ${realJwt}`)
+
+    expect(response.body).toEqual(validResponse)
+  })
+  it('should not return session with fake jwt', async () => {
+    const fakeJwt = await jwt.sign({ username: 'tom' }, 'just_a_random_key')
+    const response = await request(app)
+      .get('/auth/api/session')
+      .set('Authorization', `Bearer ${fakeJwt}`)
+
+    expect(response.body).not.toEqual(
+      expect.objectContaining({ ...mockUser, jwt: realJwt })
+    )
+  })
+})

--- a/src/auth.test.js
+++ b/src/auth.test.js
@@ -1,50 +1,65 @@
-/* globals describe it jest expect */
+/* globals afterAll beforeAll describe it jest expect */
 const { app } = require('../server')
 const request = require('supertest')
 const jwt = require('jsonwebtoken')
 
-// Prevent actual db writes/reads
+// Prevent actual db writes/reads and seed mock user
 jest.mock('./lib/db', () => ({
-  getData: jest.fn().mockResolvedValue({}),
+  getData: jest.fn().mockResolvedValue({
+    mockUser: {
+      username: 'mockUser',
+      email: 'mock@mock',
+      jwt: 'mockJwt',
+      id: 'whoCares'
+    }
+  }),
   setData: jest.fn().mockReturnValue(null)
 }))
 
 describe('auth (js5/p6)', () => {
-  const mockUser = { username: 'tom', email: 'tom@tom' }
+  const mockUser = { username: 'mockUser', email: 'mock@mock', jwt: 'mockJwt' }
 
   const validResponse = expect.objectContaining({
     ...mockUser,
     jwt: expect.any(String)
   })
 
-  // set real jwt when creating user
-  let realJwt
-  it('creating a user return a jwt', async () => {
-    const response = await request(app)
-      .post('/auth/api/users')
-      .send({
-        ...mockUser,
-        password: 'anything'
-      })
+  beforeAll(() => {
+    jest.spyOn(jwt, 'verify').mockImplementation((jwt) => {
+      if (jwt === mockUser.jwt) return mockUser
+      throw Error('BAD JWT')
+    })
+    jest.spyOn(jwt, 'decode').mockReturnValue(mockUser)
+  })
 
-    expect(response.body).toEqual(validResponse)
-    realJwt = response.body.jwt
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('creating a new user return a jwt', async () => {
+    const response = await request(app).post('/auth/api/users').send({
+      username: 'tom',
+      email: 'tom@tom',
+      password: 'anything'
+    })
+
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        jwt: expect.any(String)
+      })
+    )
   })
   it('can get session with jwt', async () => {
     const response = await request(app)
       .get('/auth/api/session')
-      .set('Authorization', `Bearer ${realJwt}`)
-
+      .set('Authorization', `Bearer ${'mockJwt'}`)
     expect(response.body).toEqual(validResponse)
   })
   it('should not return session with fake jwt', async () => {
-    const fakeJwt = await jwt.sign({ username: 'tom' }, 'just_a_random_key')
     const response = await request(app)
       .get('/auth/api/session')
-      .set('Authorization', `Bearer ${fakeJwt}`)
+      .set('Authorization', `Bearer ${'BAD_JWT'}`)
 
-    expect(response.body).not.toEqual(
-      expect.objectContaining({ ...mockUser, jwt: realJwt })
-    )
+    expect(response.body).not.toEqual(validResponse)
   })
 })

--- a/src/lib/fakeEnv.js
+++ b/src/lib/fakeEnv.js
@@ -1,0 +1,5 @@
+// In a real app this would be in a .env file and not included in the repo
+// the .env file gets loaded when the server starts and is accessible via process.env[name]
+module.exports = {
+  JWT_PRIVATE_SECRET: 'reallygreatc0der'
+}

--- a/src/lib/middleware.js
+++ b/src/lib/middleware.js
@@ -1,5 +1,6 @@
 const jwt = require("jsonwebtoken");
 const { getUser } = require("./userlist");
+const { JWT_PRIVATE_SECRET } = require('./fakeEnv')
 const middlewares = {};
 
 middlewares.setUser = (req, res, next) => {
@@ -7,11 +8,14 @@ middlewares.setUser = (req, res, next) => {
     req.user = getUser(req.session.username);
   }
 
-  const authToken = (req.headers.authorization || "").split(" ");
+  const authToken = (req.headers.authorization || '').split(' ').pop();
   if (authToken) {
-    const data = jwt.decode(authToken.pop()) || {};
-    if (data.username) {
-      req.user = getUser(data.username);
+    try {
+      // will throw error if invalid token
+      const data = jwt.verify(authToken,JWT_PRIVATE_SECRET)
+      req.user = getUser(data.username)
+    } catch (error) {
+      // Invalid authToken, don't set user and continue
     }
   }
 


### PR DESCRIPTION
Current version of authentication problem (js5/p6) isn't really verifying authToken legitimacy.

Using `jwt.decode` instead of `jwt.verify` only verifies it isn't a malformed token but does not prove who it was signed by. 

Added test case to demonstrate the bug 

Link to docs: [jwt.decode vs jwt.verify](https://www.npmjs.com/package/jsonwebtoken#jwtdecodetoken--options)

Solution was simple, replace decode with verify and wrap in try/catch as an invalid token will throw an error. 

Also ended up creating a `fakeEnv.js` file to share the private key between the auth.js file and middleware.js file, *there maybe a better solution for this.

Once this pr is approved the lesson instructions (https://www.c0d3.com/curriculum/3) problem 6 will need to be updated to include `jwt.verify` as the recommend/secure way of verifying a token 