### PR TITLE
Enable graphQL playground in production env

### DIFF
--- a/src/js6c1.js
+++ b/src/js6c1.js
@@ -55,7 +55,9 @@ type Query {
         })
       }
     }
-  }
+  },
+  introspection: true,
+  playground: true
 })
 
 server.applyMiddleware({ app: router })

--- a/src/js6c2.js
+++ b/src/js6c2.js
@@ -122,7 +122,9 @@ type Mutation {
   },
   context: ({ req }) => {
     return { req }
-  }
+  },
+  introspection: true,
+  playground: true
 })
 
 server.applyMiddleware({ app: router })


### PR DESCRIPTION
**Bug:** GraphQl Playground is no longer working.  (Broken links found on lesson pages js6/p1 https://js5.c0d3.com/js6c1/graphql , js6/p2 https://js5.c0d3.com/js6c2/graphql)

**Cause:** Switching to the dockerized version of the app properly set the node env to Production which causes apollo to turn off introspection and playground by default

**Solution:** Manually enable introspection and playground with option variables provided to ApolloServer constructor.