### PR TITLE
fix(ops): apk installing python by its alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-alpine
-RUN apk update && apk upgrade && \
+RUN apk update && apk upgrade && apk add python3 && \
     apk add --no-cache git
-RUN apk add g++ make python
+RUN apk add g++ make python3
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Closes https://github.com/garageScript/c0d3-js5/issues/9

This PR update the Dockerfile to install `python3` instead of its alias `python`.