### PR TITLE
fix: js6c2 Mismatch in resolver return type

### DIFF
--- a/src/js6c2.js
+++ b/src/js6c2.js
@@ -90,7 +90,7 @@ type Mutation {
           const data = {
             name: poke.name,
             image: poke.sprites.front_default,
-            lessons: {}
+            lessons: []
           }
           allUsers[args.pokemon] = data
           return { ...data, lessons: [] }


### PR DESCRIPTION
## Issue

The `login` query in Apollo Sandbox returns an error when run for a second time due to a mismatch in data type for the `lessons` property. The defined type is an Array, but an Object is being returned by the resolver.

## Solution

The initial user data for the `lessons` property has been changed from an Object to an Array.

## Verification

To verify the fix, run the following query twice in Apollo Sandbox:

```gql
login(pokemon: "pikachu") {
  name
}
```

Expected outcome:

```json
{
  "data": {
    "login": {
      "name": "pikachu",
      "lessons": [],
    }
  }
}
```

## Resolves
- Closes https://github.com/garageScript/c0d3-js5/issues/14
